### PR TITLE
[NEW] Module l10n_br_zip_correios added to new API

### DIFF
--- a/l10n_br_zip_correios/README.md
+++ b/l10n_br_zip_correios/README.md
@@ -1,0 +1,4 @@
+# l10n_br_zip_correios
+
+This module realize a search in Brazilian Correios webservice for zip code 
+inserted by user and fill address fields with the returned data.

--- a/l10n_br_zip_correios/__init__.py
+++ b/l10n_br_zip_correios/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Address from Brazilian Localization ZIP by Correios to Odoo
+#    Copyright (C) 2015 KMEE (http://www.kmee.com.br)
+#    @author Michell Stuttgart <michell.stuttgart@kmee.com.br>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models

--- a/l10n_br_zip_correios/__openerp__.py
+++ b/l10n_br_zip_correios/__openerp__.py
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Address from Brazilian Localization ZIP by Correios to Odoo
+#    Copyright (C) 2015 KMEE (http://www.kmee.com.br)
+#    @author Michell Stuttgart <michell.stuttgart@kmee.com.br>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Address from Brazilian Localization ZIP by Correios',
+    'description': """
+    Search address from Brazilian Localization ZIP Codes from Brazilian Correios.
+    This module fetch the whole address from webservice through zip number
+    provided by user.
+    """,
+    'license': 'AGPL-3',
+    'author': 'KMEE',
+    'version': '8.0',
+    'website': 'www.kmee.com.br',
+    'depends': [
+        'l10n_br_zip',
+    ],
+    'category': 'Localization',
+    'active': False,
+    'installable': True,
+    'external_dependencies': {
+        'python': ['suds'],
+    }
+}

--- a/l10n_br_zip_correios/i18n/pt_BR.po
+++ b/l10n_br_zip_correios/i18n/pt_BR.po
@@ -1,0 +1,41 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* l10n_br_zip_correios
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-09-02 14:28+0000\n"
+"PO-Revision-Date: 2015-09-02 14:28+0000\n"
+"Last-Translator: <Michell Stuttgart>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_br_zip_correios
+#: model:ir.model,name:l10n_br_zip_correios.model_res_company
+msgid "Companies"
+msgstr "Empresas"
+
+#. module: l10n_br_zip_correios
+#: code:addons/l10n_br_zip_correios/models/webservice_client.py:42
+#: code:addons/l10n_br_zip_correios/models/webservice_client.py:87
+#: code:addons/l10n_br_zip_correios/models/webservice_client.py:89
+#, python-format
+msgid "Error!"
+msgstr "Erro!"
+
+#. module: l10n_br_zip_correios
+#: code:addons/l10n_br_zip_correios/models/webservice_client.py:42
+#, python-format
+msgid "Invalid zip length"
+msgstr "Tamanho de CEP inválido"
+
+#. module: l10n_br_zip_correios
+#: model:ir.model,name:l10n_br_zip_correios.model_res_partner
+msgid "Partner"
+msgstr "Parceiro"
+

--- a/l10n_br_zip_correios/models/__init__.py
+++ b/l10n_br_zip_correios/models/__init__.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Address from Brazilian Localization ZIP by Correios to Odoo
+#    Copyright (C) 2015 KMEE (http://www.kmee.com.br)
+#    @author Michell Stuttgart <michell.stuttgart@kmee.com.br>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import webservice_client
+from . import res_company
+from . import res_partner

--- a/l10n_br_zip_correios/models/res_company.py
+++ b/l10n_br_zip_correios/models/res_company.py
@@ -1,0 +1,33 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Address from Brazilian Localization ZIP by Correios to Odoo
+#    Copyright (C) 2015 KMEE (http://www.kmee.com.br)
+#    @author Michell Stuttgart <michell.stuttgart@kmee.com.br>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api
+from webservice_client import WebServiceClient
+
+
+class ResCompany(models.Model, WebServiceClient):
+    _inherit = 'res.company'
+
+    @api.one
+    def zip_search(self):
+        self.get_address()
+        return super(ResCompany, self).zip_search()

--- a/l10n_br_zip_correios/models/res_partner.py
+++ b/l10n_br_zip_correios/models/res_partner.py
@@ -1,0 +1,33 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Address from Brazilian Localization ZIP by Correios to Odoo
+#    Copyright (C) 2015 KMEE (http://www.kmee.com.br)
+#    @author Michell Stuttgart <michell.stuttgart@kmee.com.br>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api
+from webservice_client import WebServiceClient
+
+
+class ResPartner(models.Model, WebServiceClient):
+    _inherit = 'res.partner'
+
+    @api.one
+    def zip_search(self):
+        self.get_address()
+        return super(ResPartner, self).zip_search()

--- a/l10n_br_zip_correios/models/webservice_client.py
+++ b/l10n_br_zip_correios/models/webservice_client.py
@@ -1,0 +1,90 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Address from Brazilian Localization ZIP by Correios to Odoo
+#    Copyright (C) 2015 KMEE (http://www.kmee.com.br)
+#    @author Michell Stuttgart <michell.stuttgart@kmee.com.br>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api
+from openerp.tools.translate import _
+from openerp.exceptions import Warning
+
+from suds.client import Client, TransportError
+from suds import WebFault
+
+
+class WebServiceClient(object):
+
+    @api.one
+    def get_address(self):
+
+        if not self.zip:
+            return
+
+        zip_str = self.zip.replace('-', '')
+
+        if len(zip_str) != 8:
+            raise Warning(_('Error!'), _('Invalid zip length'))
+
+        if not self.env['l10n_br.zip'].search([('zip', '=', zip_str)]):
+
+            # SigepWeb webservice url
+            url_prod = 'https://apps.correios.com.br/SigepMasterJPA' \
+                       '/AtendeClienteService/AtendeCliente?wsdl'
+
+            try:
+
+                # Connect Brazil Correios webservice
+                res = Client(url_prod).service.consultaCEP(zip_str)
+
+                # Search state with state_code
+                state_ids = self.env['res.country.state'].search(
+                    [('code', '=', str(res.uf))])
+
+                # city name
+                city_name = str(res.cidade.encode('utf8'))
+
+                # search city with name and state
+                city_ids = self.env['l10n_br_base.city'].search([
+                    ('name', '=', city_name),
+                    ('state_id.id', 'in', state_ids.ids)])
+
+                # Search Brazil id
+                country_ids = self.env['res.country'].search(
+                    [('code', '=', 'BR')])
+
+                values = {
+                    'zip': zip_str,
+                    'street': str(res.end.encode('utf8')) if res.end else '',
+                    'district': str(res.bairro.encode('utf8')) if res.bairro
+                    else '',
+                    'street_type': str(res.complemento.encode('utf8')) if res.complemento
+                    else '',
+                    'l10n_br_city_id': city_ids.ids[0] if city_ids else False,
+                    'state_id': state_ids.ids[0] if state_ids else False,
+                    'country_id': country_ids.ids[0] if country_ids else False,
+                }
+
+                # Create zip object
+                self.env['l10n_br.zip'].create(values)
+
+            except TransportError as e:
+                raise Warning(_('Error!'), e.message)
+            except WebFault as e:
+                raise Warning(_('Error!'), e.message)
+


### PR DESCRIPTION
Module l10n_br_zip_correios added and migrated to v8.

Adicionado módulo que completa automaticamente o endereço do parceiro/empresa através de um dado cep fornecido pelo usuário. O endereço retornado é provido pelo webservice dos Correios.
