### PR TITLE
[FIX] Erro arquivo de teste no travis e README atualizado

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+sudo: false
+language: python
+
+python:
+  - "2.7_with_system_site_packages"
+
+addons:
+  apt:
+    packages:
+      - expect-dev  # provides unbuffer utility
+      - python-lxml  # because pip installation is slow
+
+env:
+  - VERSION="8.0" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
+
+
+install:
+  - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
+  - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
+  - pip install unidecode
+  - pip install python-ldap
+  - pip install suds
+  - travis_install_nightly
+
+script:
+  - travis_run_tests
+
+after_success:
+  coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# outros
-Outros módulos Odoo que estendem as funcionalidades da localização brasileira
+# Odoo Brazil Addons
+Módulos Odoo que estendem as funcionalidades da localização brasileira.
 
 [![Build Status](https://travis-ci.org/odoo-brazil/odoo-brazil-addons.svg?branch=8.0)](https://travis-ci.org/odoo-brazil/odoo-brazil-addons)
 [![Coverage Status](https://coveralls.io/repos/odoo-brazil/odoo-brazil-addons/badge.svg?branch=8.0&service=github)](https://coveralls.io/github/odoo-brazil/odoo-brazil-addons?branch=8.0)


### PR DESCRIPTION
@mileo Consegui fazer o travis funcionar. Aparentemente estava faltando o arquivos **.travis.yml** Então o travis estava usando um arquivo _default_ que por padrão utiliza Ruby ao invés de Python.

Faltou também adicionar as dependências de módulos python externo. (pip install suds)
